### PR TITLE
Add Segment Extension

### DIFF
--- a/pyperboard/converter/converter.py
+++ b/pyperboard/converter/converter.py
@@ -5,7 +5,8 @@ from pyperboard.converter import extensions
 md = markdown.Markdown(extensions=['extra',
                                    'toc',
                                    'codehilite',
-                                   extensions.RestApiExtension()])
+                                   extensions.RestApiExtension(),
+                                   extensions.SegmentExtension()])
 
 
 def convert_md(md_text: str) -> str:

--- a/pyperboard/themes/default/static/css/segment.css
+++ b/pyperboard/themes/default/static/css/segment.css
@@ -1,0 +1,62 @@
+.content .segment {
+    display: none;
+}
+
+.segment.active {
+    display: block;
+}
+
+.segment-menu {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-right: 50%;
+  clear: left;
+}
+
+.segment-menu:last-child {
+  margin-bottom: -0.5rem;
+}
+
+.segment-menu .segment-menu-item:not(:last-child) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  margin-right: -1px;
+}
+
+.segment-menu-item:last-child {
+  margin-right: 0;
+}
+
+.segment-menu .segment-menu-item:not(:first-child) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.segment-menu-item {
+  border-color: black;
+  border-width: 1px;
+  color: #363636;
+  cursor: pointer;
+  justify-content: center;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  text-align: center;
+  white-space: nowrap;
+  -webkit-appearance: none;
+  align-items: center;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  display: inline-flex;
+  font-size: 1rem;
+  height: 2.25em;
+  line-height: 1.5;
+  position: relative;
+  vertical-align: top;
+}
+
+.segment-menu-item.is-selected {
+  background-color: #209cee;
+  color: white;
+}

--- a/pyperboard/themes/default/static/css/style.css
+++ b/pyperboard/themes/default/static/css/style.css
@@ -322,6 +322,14 @@ html, body {
     display: block;
 }
 
+.segment > h1, .segment > h2, .segment > h3, .segment > h4, .segment > h5, .segment > h6, .segment > p, .segment > table, .segment > ul, .segment > ol, .segment > aside, .segment > dl{
+    padding: 0 28px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    display: block;
+}
+
 .content > ul, .content > ol {
     padding-left: 43px;
 }

--- a/pyperboard/themes/default/static/js/segment.js
+++ b/pyperboard/themes/default/static/js/segment.js
@@ -1,0 +1,63 @@
+document.body.addEventListener("load", initSegmentMenus(), false);
+
+function initSegmentMenus() {
+
+    var segmentMenus = document.getElementsByClassName("segment-menu");
+
+    for (var i = 0; i < segmentMenus.length; i++) {
+
+        var segmentMenu = segmentMenus[i];
+
+        var segmentGroup = segmentMenu.dataset.group;
+        var segmentMenuItems = document.querySelectorAll('[id*="' + segmentGroup + '__"]');
+
+        segmentMenuItems.forEach(function (element, index) {
+            var itemSegment = element.dataset.segment;
+            var menuItem = createSegmentMenuItem(itemSegment, segmentGroup);
+
+            segmentMenu.appendChild(menuItem);
+
+            if (index === 0) {
+                menuItem.click();
+            }
+        });
+
+    }
+}
+
+function createSegmentMenuItem(segmentName, segmentGroup) {
+    var button = document.createElement('span');
+    button.classList.add('segment-menu-item');
+    button.innerText = segmentName.charAt(0).toUpperCase() + segmentName.slice(1);
+    button.dataset.segment = segmentName;
+
+    button.onclick = function (event) {
+        var parentMenu = event.target.parentNode;
+        clearSegmentButtonsState(parentMenu);
+        event.target.classList.add("is-selected");
+        showSegment(segmentName, segmentGroup);
+    };
+
+    return button;
+}
+
+
+function clearSegmentButtonsState(parentMenu) {
+
+    var segmentMenuItems = parentMenu.querySelectorAll('.segment-menu-item');
+
+    segmentMenuItems.forEach(function (element) {
+        element.classList.remove("is-selected");
+    });
+}
+
+
+function showSegment(segmentName, segmentGroup) {
+    var segments = document.querySelectorAll('[id*="' + segmentGroup + '__"]');
+
+    segments.forEach(function (element) {
+        element.classList.remove("active");
+    });
+
+    document.getElementById(segmentGroup + '__' + segmentName).classList.add("active");
+}

--- a/pyperboard/themes/default/templates/index.html
+++ b/pyperboard/themes/default/templates/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="{{ url_for('static', filename='/css/style.css') }}"/>
     <link rel="stylesheet" type="text/css" media="screen" href="{{ url_for('static', filename='/css/toc.css') }}"/>
     <link rel="stylesheet" type="text/css" media="screen" href="{{ url_for('static', filename='/css/code_highlight.css') }}"/>
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ url_for('static', filename='/css/segment.css') }}"/>
     <script src="{{ url_for('static', filename='/js/tocbot.js') }}"></script>
 </head>
 <body>
@@ -31,4 +32,5 @@
         scrollSmooth: false
     });
 </script>
+<script src="{{ url_for('static', filename='/js/segment.js') }}"></script>
 </html>


### PR DESCRIPTION
Segment extension helps to create switchable documentation segments.

Example syntax:
```
[segment-menu|doc-segment]

@@@doc-segment|first

#### First Segment
First Segment data

@@@
@@@doc-segment|second

#### Second Segment
Second Segment data

@@@
```

Example output:
```html
<nav class="segment-menu" data-group="doc-segment">
    <span class="segment-menu-item is-selected" data-segment="first">First</span>
    <span class="segment-menu-item" data-segment="second">Second</span>
</nav>

<div class="segment active" data-segment="first" id="doc-segment__first">
    <h4 id="first-segment">First Segment</h4>
    <p>First Segment data</p>
</div>
<div class="segment" data-segment="second" id="doc-segment__second">
    <h4 id="second-segment">Second Segment</h4>
    <p>Second Segment data</p>
</div>
```

Example render:

 ![screen shot 2018-05-22 at 16 05 04](https://user-images.githubusercontent.com/18231392/40364216-6967f5c6-5dda-11e8-978d-ad439c5f68c5.png)
![screen shot 2018-05-22 at 16 05 15](https://user-images.githubusercontent.com/18231392/40364233-768b6742-5dda-11e8-8509-ae3bbe7df3e9.png)

